### PR TITLE
Use ^2.3 of willdurand/negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,7 @@ exception types for [PSR-7](http://www.php-fig.org/psr/psr-7/) applications.
 
 ## Installation
 
-This library currently depends on an unreleased patch to willdurand/negotiation.
-Your first step is adding a repository entry to your `composer.json` for
-retrieving that patch:
-
-```json
-"repositories": [
-    {"type": "vcs", "url": "https://github.com/weierophinney/negotiation.git"}
-]
-```
-
-You will then need to provide a manual specification for the
-`willdurand/negotiation` requirement within `composer.json`:
-
-```json
-"require": {
-      "willdurand/negotiation": "dev-feature/plus-part-matching as 2.3.0"
-}
-```
-
-Once you have made those changes, run the following to install this library:
+Run the following to install this library:
 
 ```bash
 $ composer require weierophinney/problem-details

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "http-interop/http-middleware": "^0.4.1",
         "psr/container": "^1.0",
         "spatie/array-to-xml": "^2.3",
-        "willdurand/negotiation": "dev-feature/plus-part-matching as 2.3.0",
+        "willdurand/negotiation": "^2.3",
         "zendframework/zend-diactoros": "^1.4"
     },
     "require-dev": {
@@ -39,8 +39,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "repositories": [
-        {"type": "vcs", "url": "https://github.com/weierophinney/negotiation.git"}
-    ]
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9cdd7284920cf327c84d2add61f1ce6",
+    "content-hash": "7661d9611e02ad82f14a090225b4209c",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -257,16 +257,16 @@
         },
         {
             "name": "willdurand/negotiation",
-            "version": "dev-feature/plus-part-matching",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/weierophinney/Negotiation.git",
-                "reference": "a04be91b05daf1e33d6c599e7a7feaa6c422d5e0"
+                "url": "https://github.com/willdurand/Negotiation.git",
+                "reference": "2ba90aa46b5e77f87b55f149cfd544b8434941d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/weierophinney/Negotiation/zipball/a04be91b05daf1e33d6c599e7a7feaa6c422d5e0",
-                "reference": "a04be91b05daf1e33d6c599e7a7feaa6c422d5e0",
+                "url": "https://api.github.com/repos/willdurand/Negotiation/zipball/2ba90aa46b5e77f87b55f149cfd544b8434941d9",
+                "reference": "2ba90aa46b5e77f87b55f149cfd544b8434941d9",
                 "shasum": ""
             },
             "require": {
@@ -278,7 +278,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -286,6 +286,7 @@
                     "Negotiation\\": "src/Negotiation"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -304,10 +305,7 @@
                 "header",
                 "negotiation"
             ],
-            "support": {
-                "source": "https://github.com/weierophinney/Negotiation/tree/feature/plus-part-matching"
-            },
-            "time": "2017-05-03 15:21:16"
+            "time": "2017-05-04T12:15:48+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -1724,16 +1722,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.1",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
+                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
                 "shasum": ""
             },
             "require": {
@@ -1798,7 +1796,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01T22:17:45+00:00"
+            "time": "2017-05-03T23:30:39+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1920,18 +1918,9 @@
             "time": "2016-11-09T21:30:43+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "2.3.0",
-            "alias_normalized": "2.3.0.0",
-            "version": "dev-feature/plus-part-matching",
-            "package": "willdurand/negotiation"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "willdurand/negotiation": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
willdurand/negotiation versions 2.3.0+ have logic for matching `*` in `+` segments of subtypes.