### PR TITLE
Fixes and questions/suggestions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,17 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
+    - php: nightly
+      env:
+        - DEPS=lowest
+    - php: nightly
+      env:
+        - DEPS=locked
+    - php: nightly
+      env:
+        - DEPS=latest
+  allow_failures:
+    - php: nightly
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ install:
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
-  - if [[ $CS_CHECK == 'true' ]]; then composer license-check ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
     - php: 7.1
       env:
         - DEPS=locked
+        - CS_CHECK=true
         - TEST_COVERAGE=true
     - php: 7.1
       env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ To run tests:
 
   ```console
   $ git clone git://github.com/weierophinney/problem-details.git
-  $ cd zend-expressive
+  $ cd problem-details
   ```
 
 - Install dependencies via composer:
@@ -75,14 +75,14 @@ pull your work into the master repository. We recommend using
 
    ```console
    $ git clone git://github.com/weierophinney/problem-details.git
-   $ cd zend-expressive
+   $ cd problem-details
    ```
 
 4. Add a remote to your fork; substitute your GitHub username in the command
    below.
 
    ```console
-   $ git remote add {username} git@github.com:{username}/zend-expressive.git
+   $ git remote add {username} git@github.com:{username}/problem-details.git
    $ git fetch {username}
    ```
 
@@ -145,7 +145,7 @@ Delta compression using up to 2 threads.
 Compression objects: 100% (18/18), done.
 Writing objects: 100% (20/20), 8.19KiB, done.
 Total 20 (delta 12), reused 0 (delta 0)
-To ssh://git@github.com/{username}/zend-expressive.git
+To ssh://git@github.com/{username}/problem-details.git
    b5583aa..4f51698  HEAD -> master
 ```
 

--- a/doc/book/exception.md
+++ b/doc/book/exception.md
@@ -96,7 +96,7 @@ And it might result in the following:
     "title": "You have insufficient funds to complete the transaction.",
     "detail": "Your transaction required 5.63, but you only have 1.37 in your account",
     "account": "https://example.com/api/accounts/12345",
-    "balance": 1.37,
+    "balance": 1.37
 }
 ```
 

--- a/src/CommonProblemDetailsException.php
+++ b/src/CommonProblemDetailsException.php
@@ -80,7 +80,7 @@ trait CommonProblemDetailsException
             'type'   => $this->type,
         ];
 
-        if (! empty($this->additional)) {
+        if ($this->additional) {
             $problem = array_merge($this->additional, $problem);
         }
 

--- a/src/CommonProblemDetailsException.php
+++ b/src/CommonProblemDetailsException.php
@@ -87,7 +87,7 @@ trait CommonProblemDetailsException
         return $problem;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize() : array
     {
         return $this->toArray();
     }

--- a/src/CommonProblemDetailsException.php
+++ b/src/CommonProblemDetailsException.php
@@ -66,11 +66,11 @@ trait CommonProblemDetailsException
     }
 
     /**
-    * Serialize the exception to an array of problem details.
-    *
-    * Likely useful for the JsonSerializable implementation, but also
-    * for cases where the XML variant is desired.
-    */
+     * Serialize the exception to an array of problem details.
+     *
+     * Likely useful for the JsonSerializable implementation, but also
+     * for cases where the XML variant is desired.
+     */
     public function toArray() : array
     {
         $problem = [

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -17,7 +17,7 @@ class ConfigProvider
      *
      * @return array
      */
-    public function __invoke()
+    public function __invoke() : array
     {
         return [
             'dependencies' => $this->getDependencies(),
@@ -29,7 +29,7 @@ class ConfigProvider
      *
      * @return array
      */
-    public function getDependencies()
+    public function getDependencies() : array
     {
         return [
             'factories'  => [

--- a/src/ProblemDetailsMiddleware.php
+++ b/src/ProblemDetailsMiddleware.php
@@ -55,7 +55,7 @@ class ProblemDetailsMiddleware implements MiddlewareInterface
     private function canActAsErrorHandler(ServerRequestInterface $request) : bool
     {
         $accept = $request->getHeaderLine('Accept') ?: '*/*';
-        if (empty($accept)) {
+        if (! $accept) {
             return false;
         }
 

--- a/src/ProblemDetailsMiddleware.php
+++ b/src/ProblemDetailsMiddleware.php
@@ -70,7 +70,7 @@ class ProblemDetailsMiddleware implements MiddlewareInterface
      *
      * @return callable
      */
-    private function createErrorHandler()
+    private function createErrorHandler() : callable
     {
         /**
          * @param int $errno
@@ -80,7 +80,7 @@ class ProblemDetailsMiddleware implements MiddlewareInterface
          * @return void
          * @throws ErrorException if error is not within the error_reporting mask.
          */
-        return function ($errno, $errstr, $errfile, $errline) {
+        return function (int $errno, string $errstr, string $errfile, int $errline) : void {
             if (! (error_reporting() & $errno)) {
                 // error_reporting does not include this error
                 return;

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -184,8 +184,8 @@ class ProblemDetailsResponseFactory
         array $additional = []
     ) : ResponseInterface {
         $status = $this->normalizeStatus($status);
-        $title  = empty($title) ? $this->createTitleFromStatus($status) : $title;
-        $type   = empty($type) ? $this->createTypeFromStatus($status) : $type;
+        $title  = $title ?: $this->createTitleFromStatus($status);
+        $type   = $type ?: $this->createTypeFromStatus($status);
 
         $payload = [
             'title'  => $title,

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -293,7 +293,7 @@ class ProblemDetailsResponseFactory
         }
 
         $value = $mediaType->getValue();
-        return strstr($value, 'json')
+        return false !== strpos($value, 'json')
             ? Closure::fromCallable([$this, 'generateJsonResponse'])
             : Closure::fromCallable([$this, 'generateXmlResponse']);
     }

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -288,14 +288,9 @@ class ProblemDetailsResponseFactory
         $accept    = $request->getHeaderLine('Accept') ?: '*/*';
         $mediaType = (new Negotiator())->getBest($accept, self::NEGOTIATION_PRIORITIES);
 
-        if (! $mediaType) {
-            return Closure::fromCallable([$this, 'generateXmlResponse']);
-        }
-
-        $value = $mediaType->getValue();
-        return false !== strpos($value, 'json')
-            ? Closure::fromCallable([$this, 'generateJsonResponse'])
-            : Closure::fromCallable([$this, 'generateXmlResponse']);
+        return ! $mediaType || false === strpos($mediaType->getValue(), 'json')
+            ? Closure::fromCallable([$this, 'generateXmlResponse'])
+            : Closure::fromCallable([$this, 'generateJsonResponse']);
     }
 
     private function normalizeStatus(int $status) : int

--- a/test/ProblemDetailsAssertionsTrait.php
+++ b/test/ProblemDetailsAssertionsTrait.php
@@ -2,9 +2,6 @@
 
 namespace ProblemDetailsTest;
 
-use ProblemDetails\ProblemDetailsJsonResponse;
-use ProblemDetails\ProblemDetailsResponse;
-use ProblemDetails\ProblemDetailsXmlResponse;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 

--- a/test/ProblemDetailsExceptionTest.php
+++ b/test/ProblemDetailsExceptionTest.php
@@ -3,8 +3,8 @@
 namespace ProblemDetailsTest;
 
 use PHPUnit\Framework\TestCase;
-use ProblemDetails\ProblemDetailsException;
 use ProblemDetails\CommonProblemDetailsException;
+use ProblemDetails\ProblemDetailsException;
 
 class ProblemDetailsExceptionTest extends TestCase
 {

--- a/test/ProblemDetailsExceptionTest.php
+++ b/test/ProblemDetailsExceptionTest.php
@@ -27,12 +27,6 @@ class ProblemDetailsExceptionTest extends TestCase
         ) implements ProblemDetailsException {
             use CommonProblemDetailsException;
 
-            private $status;
-            private $type;
-            private $title;
-            private $detail;
-            private $additional;
-
             public function __construct(int $status, string $detail, string $title, string $type, array $additional)
             {
                 $this->status = $status;

--- a/test/ProblemDetailsMiddlewareFactoryTest.php
+++ b/test/ProblemDetailsMiddlewareFactoryTest.php
@@ -2,11 +2,11 @@
 
 namespace ProblemDetailsTest;
 
-use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use ProblemDetails\ProblemDetailsMiddleware;
 use ProblemDetails\ProblemDetailsMiddlewareFactory;
 use ProblemDetails\ProblemDetailsResponseFactory;
+use Psr\Container\ContainerInterface;
 
 class ProblemDetailsMiddlewareFactoryTest extends TestCase
 {

--- a/test/ProblemDetailsMiddlewareTest.php
+++ b/test/ProblemDetailsMiddlewareTest.php
@@ -138,6 +138,6 @@ class ProblemDetailsMiddlewareTest extends TestCase
         $this->expectException(TestAsset\RuntimeException::class);
         $this->expectExceptionMessage('Thrown!');
         $this->expectExceptionCode(507);
-        $result = $middleware->process($this->request->reveal(), $delegate->reveal());
+        $middleware->process($this->request->reveal(), $delegate->reveal());
     }
 }

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -103,7 +103,6 @@ class ProblemDetailsResponseFactoryTest extends TestCase
 
         $factory = new ProblemDetailsResponseFactory();
 
-        $exception = new RuntimeException();
         $response = $factory->createResponseFromThrowable(
             $this->request->reveal(),
             $e->reveal()
@@ -155,7 +154,6 @@ class ProblemDetailsResponseFactoryTest extends TestCase
 
         $factory = new ProblemDetailsResponseFactory(ProblemDetailsResponseFactory::INCLUDE_THROWABLE_DETAILS);
 
-        $exception = new RuntimeException();
         $response = $factory->createResponseFromThrowable(
             $this->request->reveal(),
             $second

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -5,7 +5,6 @@ namespace ProblemDetailsTest;
 use PHPUnit\Framework\TestCase;
 use ProblemDetails\InvalidResponseBodyException;
 use ProblemDetails\ProblemDetailsException;
-use ProblemDetails\ProblemDetailsResponse;
 use ProblemDetails\ProblemDetailsResponseFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;


### PR DESCRIPTION
I have couple fixes:
- added type hinting and return type in some places
- removed unused imports
- removed unused variables
- fixed indents (PHPDocs)
- simplify some statements (with `empty` function calls)
- updated travis configuration

and some questions/suggestions:
- [ ] is there any reason why XML is default, not JSON? Apigility 1 was using JSON by default, and I would keep it here as well. As I can see now - to convert arrays to XML we need to us external library, but to use JSON we are using internal methods, so I think it's better, and we should recommend using JSON if possible. Maybe we can go even further and require to add XML converter dependency only in case someone wants use XML responses?
- [ ] don't we need to add  `"ext-json": "*",` into composer? I remember when you said that in some configuration json is not complied with PHP. Maybe now (with PHP 7.1) is different?
- [ ] maybe - instead of merging "additional" params array with default information - we should add all additional data in a subkey?
- [ ] I'd update everywhere (also in tests) return types, type hinting, class properties and PHPDocs. Now for me in the library is a bit messy in PHPDocs, sometimes we have there something, sometimes just part, sometimes we don't have it at all. We can synchronize PHPDocs with type hinting and return types using phpcs. (not sure, but I think `phpDocumentor` is using only PHPDocs to generate docs)
- [ ] maybe we should move exceptions to `ProblemDetails\Exception` namespace? Maybe even we should think about better struct of the library. I know that is is very simple, but it is not so nice to have all classes on one level. Then we can remove "ProblemDetails" from many of these classes and leave it only in the namespace. Now `ProblemDetails` is duplicated (namespace and class name).

I really like that we are using only PHP 7.1! It simplify our lives a lot! 👍 
